### PR TITLE
Update package list first

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,8 @@
 ---
+- name: Update the package lists
+  apt:
+    update_cache: yes
+
 - name: Ensure dependencies are installed.
   apt:
     name:


### PR DESCRIPTION
If `apt-get update` was never executed on the node, it is failed with `No package matching 'gnupg2' is available`.
To solve this issue, update the package list as the first job.