### PR TITLE
containerd.runtimes.runc.options SystemdCgroup = true

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Service controls. You can install containerd but not have it running or enabled 
 
 Write containerd defaults to the containerd config.toml file.
 
+    containerd_config_cgroup_driver_systemd: false
+
+Set systemd as cgroup driver in config.toml. Only valid with `containerd_config_default_write: true`
+
     docker_apt_release_channel: stable
     docker_apt_arch: '{{ (ansible_architecture == "aarch64") | ternary("arm64", "amd64") }}'
     docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,10 @@ containerd_service_enabled: true
 # Write a default containerd config.toml file.
 containerd_config_default_write: true
 
+# Set systemd as cgroup driver in config.toml
+# Only use with containerd_config_default_write: true
+containerd_config_cgroup_driver_systemd: false
+
 # Used only for Debian/Ubuntu. Switch 'stable' to 'nightly' if needed.
 docker_apt_release_channel: stable
 docker_apt_arch: '{{ (ansible_architecture == "aarch64") | ternary("arm64", "amd64") }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,7 @@
     dest: /tmp/containerd_config.toml
     content: "{{ containerd_config_default.stdout }}"
   when: containerd_config_default_write
+  changed_when: false
 
 - name: Set Cgroup driver to systemd
   lineinfile:
@@ -41,6 +42,16 @@
     state: present
     path: /tmp/containerd_config.toml
   when: containerd_config_default_write and containerd_config_cgroup_driver_systemd
+  changed_when: false
+
+- name: Make sure  SystemdCgroup = false is not set
+  ansible.builtin.lineinfile:
+    path: /tmp/containerd_config.toml
+    state: absent
+    line: '            SystemdCgroup = false'
+  notify: restart containerd
+  when: containerd_config_default_write and containerd_config_cgroup_driver_systemd
+  changed_when: false
 
 - name: Copy config.toml to /etc/containerd
   copy:
@@ -54,6 +65,7 @@
   file:
     path: /tmp/containerd_config.toml
     state: absent
+  changed_when: false
 
 - name: Ensure containerd is restarted immediately if necessary.
   meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,12 +28,32 @@
   register: containerd_config_default
   when: containerd_config_default_write
 
-- name: Write defaults to config.toml.
+- name: Prepare containerd/config.toml from default config
   copy:
-    dest: /etc/containerd/config.toml
+    dest: /tmp/containerd_config.toml
     content: "{{ containerd_config_default.stdout }}"
+  when: containerd_config_default_write
+
+- name: Set Cgroup driver to systemd
+  lineinfile:
+    insertafter: '.*\[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options\]$'
+    line: '          SystemdCgroup = true'
+    state: present
+    path: /tmp/containerd_config.toml
+  when: containerd_config_default_write and containerd_config_cgroup_driver_systemd
+
+- name: Copy config.toml to /etc/containerd
+  copy:
+    remote_src: true
+    src: /tmp/containerd_config.toml
+    dest: /etc/containerd/config.toml
   notify: restart containerd
   when: containerd_config_default_write
+
+- name: Cleanup temporary file
+  file:
+    path: /tmp/containerd_config.toml
+    state: absent
 
 - name: Ensure containerd is restarted immediately if necessary.
   meta: flush_handlers


### PR DESCRIPTION
I took the commits from #3 and added some steps on top that should ensure that the playbook is idempotent, and added a new step to fix an issue I ran into over the weekend.

Happy to move my commit to #3 or whatever suit to get it merged.