### PR TITLE
Update setup-Debian.yml

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,6 +6,7 @@
       - ca-certificates
       - gnupg2
     state: present
+    update_cache: true
 
 - name: Add Docker apt key.
   apt_key:


### PR DESCRIPTION
On new targeted Ubuntu 22.04 nodes, `apt update` needs to be performed to install gnupg2. Simply adding `update_cache: true` in the task "Ensure dependencies are installed".