### PR TITLE
Add apt filename similar to ansible-role-docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Set systemd as cgroup driver in config.toml. Only valid with `containerd_config_
     docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
     docker_apt_ignore_key_error: true
     docker_apt_gpg_key: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+    docker_apt_filename: "docker"
 
 Apt installation paramemeters, useful if you want to switch from the stable channel releases, or install on a different CPU architecture (e.g. `arm64`).
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ docker_apt_arch: '{{ (ansible_architecture == "aarch64") | ternary("arm64", "amd
 docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 docker_apt_ignore_key_error: true
 docker_apt_gpg_key: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+docker_apt_filename: "docker"
 
 # Used only for RedHat/CentOS/Fedora.
 docker_yum_repo_url: https://download.docker.com/linux/{{ (ansible_distribution == "Fedora") | ternary("fedora","centos") }}/docker-ce.repo

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -28,4 +28,5 @@
   apt_repository:
     repo: "{{ docker_apt_repository }}"
     state: present
+    filename: "{{ docker_apt_filename }}"
     update_cache: true


### PR DESCRIPTION
**What**
When using the docker role and containerd role our source list gets a conflict. 

The docker role puts sources into docker.list while containerd puts those into whatever the default is. 

So this leads to conflicts.

**Breaking Change**
Yes. The default value for docker_apt_filename is currently "docker". So this might break stuff.

Alternativley we could use an empty string as default value and omit it when its not defined. 

Any opinions on that one?

**References**
- Related PR on docker role: https://github.com/geerlingguy/ansible-role-docker/pull/369