### PR TITLE
Use apt module on failover

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -16,7 +16,9 @@
   ignore_errors: "{{ docker_apt_ignore_key_error }}"
 
 - name: Ensure curl is present (on older systems without SNI).
-  package: name=curl state=present
+  apt: 
+    name: curl
+    state: present
   when: add_repository_key is failed
 
 - name: Add Docker apt key (alternative for older systems without SNI).

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -16,7 +16,7 @@
   ignore_errors: "{{ docker_apt_ignore_key_error }}"
 
 - name: Ensure curl is present (on older systems without SNI).
-  apt: 
+  apt:
     name: curl
     state: present
   when: add_repository_key is failed


### PR DESCRIPTION
When curl is used as a failover for the docker key use the apt module instead of package.